### PR TITLE
Update parameter names of AWS SSM Parameter Store keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ deploy:         ## Deploy SAM application
 		--capabilities CAPABILITY_IAM \
 		--parameter-overrides \
 			DatadogApiKeySSMParamName="$(DATADOG_API_KEY_SSM_PARAM_NAME)" \
-			DatadogApplicationKeySSMParamName="$(DATADOG_API_KEY_SSM_PARAM_NAME)" \
-			SlackTokenSSMParamName="$(DATADOG_API_KEY_SSM_PARAM_NAME)" \
+			DatadogApplicationKeySSMParamName="$(DATADOG_APP_KEY_SSM_PARAM_NAME)" \
+			SlackTokenSSMParamName="$(SLACK_TOKEN_SSM_PARAM_NAME)" \
 			SlackChannelId="$(SLACK_CHANNEL_ID)" \
 			ExecutionIAMRoleArn="$(EXECUTION_IAM_ROLE_ARN)"
 

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ deploy:         ## Deploy SAM application
 		--stack-name $(CLOUD_FORMATION_STACK_NAME) \
 		--capabilities CAPABILITY_IAM \
 		--parameter-overrides \
-			DatadogApiKeySSM="$(DATADOG_API_KEY_SSM)" \
-			DatadogApplicationKeySSM="$(DATADOG_APP_KEY_SSM)" \
-			SlackTokenSSM="$(SLACK_TOKEN_SSM)" \
+			DatadogApiKeySSMParamName="$(DATADOG_API_KEY_SSM_PARAM_NAME)" \
+			DatadogApplicationKeySSMParamName="$(DATADOG_API_KEY_SSM_PARAM_NAME)" \
+			SlackTokenSSMParamName="$(DATADOG_API_KEY_SSM_PARAM_NAME)" \
 			SlackChannelId="$(SLACK_CHANNEL_ID)" \
 			ExecutionIAMRoleArn="$(EXECUTION_IAM_ROLE_ARN)"
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You could use [Slack Legacy tokens](https://api.slack.com/custom-integrations/le
 
 ## Local development
 
-**Setup environment variables in env.json**
+#### Setup environment variables in env.json
 
 ```json
 {
@@ -46,12 +46,12 @@ You could use [Slack Legacy tokens](https://api.slack.com/custom-integrations/le
 }
 ```
 
-- The default of `CUSTOM_METRICS_INCLUDED_PER_HOST` is 100 (Pro plan)
+- The default of `CUSTOM_METRICS_INCLUDED_PER_HOST` is 100 (Pro plan).
 - The `LOG_LEVEL` accepted `DEBUG`, `INFO`, `WARN`, `ERROR` values
 
-See [./env.json.sample](./env.json.sample)
+See [./env.json.sample](./env.json.sample) for more information.
 
-**Invoking function locally using a local sample payload**
+#### Invoking function locally using a local sample payload
 
 ```bash
 sam local invoke -t template.yaml --no-event -n env.json "checkDatadogCustomMetricsUsage" <<< "{}"
@@ -68,6 +68,13 @@ aws ssm put-parameter \
   --value <Your Datadog API Key> \
   --type SecureString
 ```
+
+The needed secrets are:
+- The Datadog API Key
+- The Datadog Application Key
+- The Slack Token
+
+See [setup process](#setup-process) for more information.
 
 Then build and package by:
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ You could use [Slack Legacy tokens](https://api.slack.com/custom-integrations/le
 ```json
 {
   "checkDatadogCustomMetricsUsage": {
-    "DATADOG_API_KEY_SSM": "<The parameter store key of your Datadog API Key>",
-    "DATADOG_APP_KEY_SSM": "<The parameter store key of your Datadog APP Key>",
+    "DATADOG_API_KEY_SSM_PARAM_NAME": "<The AWS Parameter Store name of your Datadog API Key>",
+    "DATADOG_APP_KEY_SSM_PARAM_NAME": "<The AWS Parameter Store name of your Datadog APP Key>",
     "CUSTOM_METRICS_INCLUDED_PER_HOST": "100",
-    "SLACK_TOKEN_SSM": "<The parameter store key of your Slack token>",
+    "SLACK_TOKEN_SSM_PARAM_NAME": "<The AWS Parameter Store name of your Slack token>",
     "SLACK_CHANNEL_ID": "<Your Slack Channel ID>",
     "LOG_LEVEL": "DEBUG"
   }
@@ -54,7 +54,7 @@ See [./env.json.sample](./env.json.sample)
 **Invoking function locally using a local sample payload**
 
 ```bash
-sam local invoke --no-event -n env.json "checkDatadogCustomMetricsUsage" <<< "{}"
+sam local invoke -t template.yaml --no-event -n env.json "checkDatadogCustomMetricsUsage" <<< "{}"
 ```
 
 ## Deployment
@@ -78,9 +78,9 @@ make build package
 Finally, deploy by following command
 
 ```bash
-DATADOG_API_KEY_SSM=<Your Parameter Store Key> && \
-  DATADOG_APP_KEY_SSM=<Your Parameter Store Key> && \
-  SLACK_TOKEN_SSM=<Your Parameter Store Key> && \
+DATADOG_API_KEY_SSM_PARAM_NAME=<Your Parameter Store Key> && \
+  DATADOG_APP_KEY_SSM_PARAM_NAME=<Your Parameter Store Key> && \
+  SLACK_TOKEN_SSM_PARAM_NAME=<Your Parameter Store Key> && \
   SLACK_CHANNEL_ID=<Your Slack Channel ID> && \
   EXECUTION_IAM_ROLE_ARN=<The Arn of IAM Role for executing or leave blank to create automatically> && \
   make deploy

--- a/env.json.sample
+++ b/env.json.sample
@@ -1,9 +1,9 @@
 {
   "checkDatadogCustomMetricsUsage": {
-    "DATADOG_API_KEY_SSM": "<The parameter store key of your Datadog API Key>",
-    "DATADOG_APP_KEY_SSM": "<The parameter store key of your Datadog APP Key>",
+    "DATADOG_API_KEY_SSM_PARAM_NAME": "<The AWS Parameter Store name of your Datadog API Key>",
+    "DATADOG_APP_KEY_SSM_PARAM_NAME": "<The AWS Parameter Store name of your Datadog APP Key>",
     "CUSTOM_METRICS_INCLUDED_PER_HOST": "100",
-    "SLACK_TOKEN_SSM": "<The parameter store key of your Slack token>",
+    "SLACK_TOKEN_SSM_PARAM_NAME": "<The AWS Parameter Store name of your Slack token>",
     "SLACK_CHANNEL_ID": "<Your Slack Channel ID>",
     "LOG_LEVEL": "DEBUG"
   }

--- a/functions/check-custom-metrics-usage.js
+++ b/functions/check-custom-metrics-usage.js
@@ -59,14 +59,17 @@ async function getSSMValue(key) {
 }
 
 async function init() {
-  log.debug(`Datadog api key SSM Parameter Store name: ${process.env['DATADOG_API_KEY_SSM']}`);
-  datadogAuth.apiKey = await getSSMValue(process.env['DATADOG_API_KEY_SSM']);
+  const ddApiKeyParamName = process.env['DATADOG_API_KEY_SSM_PARAM_NAME'];
+  log.debug(`The Datadog API Key Parameter Store name: ${ddApiKeyParamName}`);
+  datadogAuth.apiKey = await getSSMValue(ddApiKeyParamName);
 
-  log.debug(`Datadog api key SSM Parameter Store name: ${process.env['DATADOG_APP_KEY_SSM']}`);
-  datadogAuth.appKey = await getSSMValue(process.env['DATADOG_APP_KEY_SSM']);
+  const ddAppKeyParamName = process.env['DATADOG_APP_KEY_SSM_PARAM_NAME'];
+  log.debug(`The Datadog Application Key Parameter Store name: ${ddAppKeyParamName}`);
+  datadogAuth.appKey = await getSSMValue(ddAppKeyParamName);
 
-  log.debug(`Datadog api key SSM Parameter Store name: ${process.env['SLACK_TOKEN_SSM']}`);
-  slackAuth.token = await getSSMValue(process.env['SLACK_TOKEN_SSM']);
+  const slackTokenParamName = process.env['SLACK_TOKEN_SSM_PARAM_NAME'];
+  log.debug(`The Slack Token Parameter Store name: ${slackTokenParamName}`);
+  slackAuth.token = await getSSMValue(slackTokenParamName);
 }
 
 async function notify(startHr, endHr, checkResult) {

--- a/template.yaml
+++ b/template.yaml
@@ -7,10 +7,10 @@ Globals:
   Function:
     Timeout: 60
 Parameters:
-  DatadogApiKeySSM:
+  DatadogApiKeySSMParamName:
     Type: AWS::SSM::Parameter::Name
     Description: The Systems Manager Parameter Store name of your Datadog API Key.
-  DatadogApplicationKeySSM:
+  DatadogApplicationKeySSMParamName:
     Type: AWS::SSM::Parameter::Name
     Description: The Systems Manager Parameter Store name of your Datadog Application Key.
   CustomMetricsIncludedPerHost:
@@ -19,7 +19,7 @@ Parameters:
     Description: >
       The number of Datadog custom metrics included per host. It depends on your plan.
       You can also input your own number for customizing the upper limit.
-  SlackTokenSSM:
+  SlackTokenSSMParamName:
     Type: AWS::SSM::Parameter::Name
     Default: ''
     Description: The Systems Manager Parameter Store name of Slack token for sending message.
@@ -64,10 +64,10 @@ Resources:
       Environment:
         Variables:
           LOG_LEVEL: INFO
-          DATADOG_API_KEY_SSM: !Ref DatadogApiKeySSM
-          DATADOG_APP_KEY_SSM: !Ref DatadogApplicationKeySSM
+          DATADOG_API_KEY_SSM_PARAM_NAME: !Ref DatadogApiKeySSMParamName
+          DATADOG_APP_KEY_SSM_PARAM_NAME: !Ref DatadogApplicationKeySSMParamName
           CUSTOM_METRICS_INCLUDED_PER_HOST: !Ref CustomMetricsIncludedPerHost
-          SLACK_TOKEN_SSM: !Ref SlackTokenSSM
+          SLACK_TOKEN_SSM_PARAM_NAME: !Ref SlackTokenSSMParamName
           SLACK_CHANNEL_ID: !Ref SlackChannelId
           SLACK_MESSAGE_TEMPLATE: !Ref SlackMessageTemplate
 
@@ -93,9 +93,9 @@ Resources:
                 Action:
                   - ssm:GetParameter
                 Resource:
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${DatadogApiKeySSM}
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${DatadogApplicationKeySSM}
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${SlackTokenSSM}
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${DatadogApiKeySSMParamName}
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${DatadogApplicationKeySSMParamName}
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${SlackTokenSSMParamName}
 Outputs:
   CheckDatadogCustomMetricsUsageFunction:
     Description: "Check datadog custom metrics usage function"


### PR DESCRIPTION
Changes:

#### Update Cloudformation template parameter names

Before | After
-----  | -----
DatadogApiKeySSM | DatadogApiKeySSMParamName
DatadogApplicationKeySSM | DatadogApplicationKeySSMParamName
SlackTokenSSM | SlackTokenSSMParamName

#### Update `checkDatadogCustomMetricsUsage` environment variable names

Before | After
-----  | -----
DATADOG_API_KEY_SSM | DATADOG_API_KEY_SSM_PARAM_NAME
DATADOG_APP_KEY_SSM | DATADOG_APP_KEY_SSM_PARAM_NAME
 SLACK_TOKEN_SSM    | SLACK_TOKEN_SSM_PARAM_NAME